### PR TITLE
Notify withdrawal proofs via SSE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.spring_boot_version = '2.1.4.RELEASE'
-    ext.notary_version = '3b8755637597eac3ebc07f149f089222e6ec1887'
+    ext.notary_version = '61b9633bdc44a87a28801d9554f51122c1ef5365'
     ext.chain_adapter_client_version= '3339510465bc908b89bc09a35f150fc5f7c1ef92'
 
     repositories {

--- a/event-notification/build.gradle
+++ b/event-notification/build.gradle
@@ -1,0 +1,84 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        jcenter()
+        // gradle plugins repository
+        gradlePluginPortal()
+    }
+    dependencies {
+        //Spring-boot
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:$spring_boot_version"
+    }
+}
+
+plugins {
+    id 'jp.co.soramitsu.sora-plugin' version '0.1.2'
+}
+
+group 'd3'
+version '1.0'
+
+// sora-plugin configs
+soramitsu {
+    projectGroup = 'd3-deploy'
+    docker {
+        // docker tag
+        tag = System.getenv("TAG")
+        // jar file that is used in the generated Dockerfile
+        jar = new File("build/libs/${project.name}-${project.version}.jar")
+        // the rest in configured using env variables
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceCompatibility = 1.8
+
+apply plugin: 'application'
+apply plugin: "kotlin-spring" // See https://kotlinlang.org/docs/reference/compiler-plugins.html#kotlin-spring-compiler-plugin
+apply plugin: 'io.spring.dependency-management'
+apply plugin: 'org.springframework.boot'
+apply plugin: 'idea'
+apply plugin: 'java'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+dependencies {
+
+    //Spring-boot
+    implementation("org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version") {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+    
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    // RMQ
+    implementation "com.rabbitmq:amqp-client:5.6.0"
+    // Notification events model
+    implementation "com.github.d3ledger.notary:notifications-model:$notary_version"
+    // https://mvnrepository.com/artifact/io.reactivex.rxjava2/rxkotlin
+    compile "io.reactivex.rxjava2:rxjava:2.0.0"
+    compile "io.reactivex.rxjava2:rxkotlin:2.0.0"
+}
+
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+mainClassName = "com.d3.notification.NotificationMain"
+
+jar {
+    manifest {
+        attributes(
+                'Main-Class': mainClassName
+        )
+    }
+}
+
+tasks.withType(Test)  {
+    maxParallelForks = 1
+}

--- a/event-notification/src/main/kotlin/com/d3/notification/NotificationMain.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/NotificationMain.kt
@@ -1,0 +1,13 @@
+@file:JvmName("NotificationMain")
+
+package com.d3.notification
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class Notification
+
+fun main(args: Array<String>) {
+    SpringApplication.run(Notification::class.java, *args)
+}

--- a/event-notification/src/main/kotlin/com/d3/notification/controller/NotificationController.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/controller/NotificationController.kt
@@ -1,0 +1,47 @@
+package com.d3.notification.controller
+
+import com.d3.notification.listener.SoraNotificationListener
+import com.google.gson.Gson
+import mu.KLogging
+import org.springframework.http.MediaType
+import org.springframework.http.codec.ServerSentEvent
+import org.springframework.web.bind.annotation.*
+import reactor.core.publisher.Flux
+import java.util.*
+
+/**
+ * Controller that is responsible for Sora event handling
+ */
+@CrossOrigin(origins = ["*"], allowCredentials = "true", allowedHeaders = ["*"])
+@RestController
+@RequestMapping("/notification")
+class NotificationController(private val notificationListener: SoraNotificationListener) {
+
+    private val gson = Gson()
+
+    /**
+     * Subscribes to `withdrawal proofs collected` event stream
+     */
+    @GetMapping(path = ["/subscribe/withdrawalProofs/{accountId}"], produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun subscribeWithdrawalProofs(@PathVariable accountId: String): Flux<ServerSentEvent<String>> {
+        val clientID = UUID.randomUUID()
+        logger.info("New subscriber. Client id $clientID")
+        return Flux.create { emitter ->
+            val disposable = notificationListener.subscribeWithdrawalProofs { soraWithdrawalProofEvent ->
+                if (soraWithdrawalProofEvent.accountIdToNotify == accountId) {
+                    val event = ServerSentEvent.builder<String>()
+                        .event("sora-withdrawal-proofs-event")
+                        .data(gson.toJson(soraWithdrawalProofEvent))
+                        .build()
+                    emitter.next(event)
+                }
+            }
+            emitter.onDispose {
+                logger.info("Dispose client $clientID")
+                disposable.dispose()
+            }
+        }
+    }
+
+    companion object : KLogging()
+}

--- a/event-notification/src/main/kotlin/com/d3/notification/listener/SoraNotificationListener.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/listener/SoraNotificationListener.kt
@@ -1,0 +1,92 @@
+package com.d3.notification.listener
+
+import com.d3.notifications.event.SoraEthWithdrawalProofsEvent
+import com.google.gson.Gson
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.Delivery
+import io.reactivex.subjects.PublishSubject
+import mu.KLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.io.Closeable
+
+private const val SORA_EVENTS_QUEUE_NAME = "sora_notification_events_queue"
+private const val EVENT_TYPE_HEADER = "event_type"
+
+/**o
+ * Listener that listens to Sora events that comes through RabbitMQ
+ */
+@Component
+class SoraNotificationListener(
+    @Value("\${rmq.host}")
+    private val rmqHost: String,
+    @Value("\${rmq.port}")
+    private val rmqPort: Int
+) : Closeable {
+
+    private val gson = Gson()
+    private val connectionFactory = ConnectionFactory()
+    private val channel: Channel
+    private val connection: Connection
+    private val sourceEthWithdrawalProofs = PublishSubject.create<SoraEthWithdrawalProofsEvent>()
+    private val consumerTag: String
+
+    /**
+     * Initiates RabbitMQ connection, creates listeners, etc
+     */
+    init {
+        // Connect to RMQ
+        connectionFactory.host = rmqHost
+        connectionFactory.port = rmqPort
+        connection = connectionFactory.newConnection()
+        channel = connection.createChannel()
+        // Create queue that handles duplicates
+        channel.queueDeclare(SORA_EVENTS_QUEUE_NAME, true, false, false, createDeduplicationArgs())
+        consumerTag = channel.basicConsume(SORA_EVENTS_QUEUE_NAME, true,
+            { _: String, delivery: Delivery ->
+                val json = String(delivery.body)
+                val eventType = delivery.properties.headers[EVENT_TYPE_HEADER]?.toString() ?: ""
+                logger.info("Got event type $eventType with message ${String(delivery.body)}")
+                when (eventType) {
+                    // Handle proof collection events
+                    SoraEthWithdrawalProofsEvent::class.java.canonicalName -> {
+                        val withdrawalEventProof = gson.fromJson(json, SoraEthWithdrawalProofsEvent::class.java)
+                        //logger.info("Got withdrawal proof event: $withdrawalEventProof")
+                        sourceEthWithdrawalProofs.onNext(withdrawalEventProof)
+                    }
+                    else -> {
+                        logger.warn("Event type $eventType is not supported")
+                    }
+                }
+            }
+            , { _ -> })
+    }
+
+    /**
+     * Subscribes to `enough proofs collected` events
+     * @param subscribeLogic - subscribing logic
+     */
+    fun subscribeWithdrawalProofs(subscribeLogic: (SoraEthWithdrawalProofsEvent) -> Unit) =
+        sourceEthWithdrawalProofs.subscribe(subscribeLogic)
+
+    /**
+     * Creates RabbitMQ queue arguments for deduplication
+     */
+    private fun createDeduplicationArgs() = hashMapOf<String, Any>(
+        // enable deduplication
+        Pair("x-message-deduplication", true),
+        // save deduplication data on disk rather that memory
+        Pair("x-cache-persistence", "disk"),
+        // save deduplication data 1 hour
+        Pair("x-cache-ttl", 60_000 * 60)
+    )
+
+    override fun close() {
+        channel.basicCancel(consumerTag)
+        connection.close()
+    }
+
+    companion object : KLogging()
+}

--- a/event-notification/src/main/resources/application.yml
+++ b/event-notification/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+rmq:
+  host: d3-rmq
+  port: 5672

--- a/event-notification/src/main/resources/logback.xml
+++ b/event-notification/src/main/resources/logback.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>[%d{dd.MM.yyyy HH:mm:ss,SSS}] event-notification [%-5p] [%t] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.lordofthejars.foo" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'report-system'
 include 'data-collector'
 include 'report-service'
+include 'event-notification'


### PR DESCRIPTION
Now we can notify users about Sora events via SSE. Tests are coming soon.