### PR TITLE
Add acks in notifications

### DIFF
--- a/event-notification/src/main/kotlin/com/d3/notification/controller/NotificationController.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/controller/NotificationController.kt
@@ -41,13 +41,17 @@ class NotificationController(
         logger.info("New subscriber. Account id $accountId. Client id $clientID")
         return Flux.create { emitter ->
             val disposable = notificationListener.subscribeWithdrawalProofs { soraWithdrawalProofEvent ->
-                if (soraWithdrawalProofEvent.accountIdToNotify == accountId) {
-                    val event = ServerSentEvent.builder<String>()
-                        .event("sora-withdrawal-proofs-event")
-                        .data(gson.toJson(soraWithdrawalProofEvent))
-                        .build()
-                    logger.info("Publish to client $clientID. Event $soraWithdrawalProofEvent")
-                    emitter.next(event)
+                try {
+                    if (soraWithdrawalProofEvent.accountIdToNotify == accountId) {
+                        val event = ServerSentEvent.builder<String>()
+                            .event("sora-withdrawal-proofs-event")
+                            .data(gson.toJson(soraWithdrawalProofEvent))
+                            .build()
+                        logger.info("Publish to client $clientID. Event $soraWithdrawalProofEvent")
+                        emitter.next(event)
+                    }
+                } catch (e: Exception) {
+                    logger.error("Cannot stream events via SSE for client $clientID", e)
                 }
             }
             emitter.onDispose {

--- a/event-notification/src/main/kotlin/com/d3/notification/exception/RepeatableError.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/exception/RepeatableError.kt
@@ -1,0 +1,6 @@
+package com.d3.notification.exception
+
+/**
+ * Exception wrapper that is used to signalize that the failed operation may be repeated
+ */
+class RepeatableError(message: String, cause: Throwable) : Exception(message, cause)

--- a/event-notification/src/main/kotlin/com/d3/notification/exception/RepeatableError.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/exception/RepeatableError.kt
@@ -1,6 +1,0 @@
-package com.d3.notification.exception
-
-/**
- * Exception wrapper that is used to signalize that the failed operation may be repeated
- */
-class RepeatableError(message: String, cause: Throwable) : Exception(message, cause)

--- a/event-notification/src/main/kotlin/com/d3/notification/listener/SoraNotificationListener.kt
+++ b/event-notification/src/main/kotlin/com/d3/notification/listener/SoraNotificationListener.kt
@@ -1,6 +1,7 @@
 package com.d3.notification.listener
 
 import com.d3.notification.domain.EthWithdrawalProofs
+import com.d3.notification.exception.RepeatableError
 import com.d3.notification.repository.EthWithdrawalProofRepository
 import com.d3.notifications.event.SoraEthWithdrawalProofsEvent
 import com.google.gson.Gson
@@ -12,9 +13,13 @@ import com.rabbitmq.client.impl.DefaultExceptionHandler
 import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.PublishSubject
 import mu.KLogging
+import org.hibernate.exception.JDBCConnectionException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import org.springframework.transaction.CannotCreateTransactionException
 import java.io.Closeable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import kotlin.system.exitProcess
 
 private const val SORA_EVENTS_RX_QUEUE_NAME = "sora_notification_events_rx_queue"
@@ -40,6 +45,8 @@ class SoraNotificationListener(
     private val connection: Connection
     private val sourceEthWithdrawalProofs = PublishSubject.create<SoraEthWithdrawalProofsEvent>()
     private val consumerTags = ArrayList<String>()
+    private val persistencyExecutorService = Executors.newSingleThreadExecutor()
+    private val rxExecutorService = Executors.newSingleThreadExecutor()
 
     /**
      * Initiates RabbitMQ connection, creates listeners, etc
@@ -50,6 +57,7 @@ class SoraNotificationListener(
         connectionFactory.port = rmqPort
         connection = connectionFactory.newConnection()
         channel = connection.createChannel()
+        channel.basicQos(16)
         // Handle connection errors
         connectionFactory.exceptionHandler = object : DefaultExceptionHandler() {
             override fun handleConnectionRecoveryException(conn: Connection, exception: Throwable) {
@@ -67,20 +75,31 @@ class SoraNotificationListener(
         // Create queue that handles duplicates. The queue just publishes incoming events via RX
         channel.queueDeclare(SORA_EVENTS_RX_QUEUE_NAME, true, false, false, createDeduplicationArgs())
         channel.queueBind(SORA_EVENTS_RX_QUEUE_NAME, SORA_EVENTS_EXCHANGE_NAME, "")
-        consumerTags.add(registerEthWithdrawalProofConsumer(SORA_EVENTS_RX_QUEUE_NAME) {
-            logger.info("Publish event via RX. Event $it")
-            sourceEthWithdrawalProofs.onNext(it)
+        consumerTags.add(registerEthWithdrawalProofConsumer(SORA_EVENTS_RX_QUEUE_NAME) { event ->
+            rxExecutorService.submit {
+                logger.info("Publish event via RX. Event $event")
+                sourceEthWithdrawalProofs.onNext(event)
+            }
         })
 
         // Create queue that handles duplicates. The queue is responsible for persisting events in the DB
         channel.queueDeclare(SORA_EVENTS_PERSIST_QUEUE_NAME, true, false, false, createDeduplicationArgs())
         channel.queueBind(SORA_EVENTS_PERSIST_QUEUE_NAME, SORA_EVENTS_EXCHANGE_NAME, "")
-        consumerTags.add(registerEthWithdrawalProofConsumer(SORA_EVENTS_PERSIST_QUEUE_NAME) {
-            try {
-                logger.info("Persist event. Event $it")
-                ethWithdrawalProofRepository.save(EthWithdrawalProofs.mapDomain(it))
-            } catch (e: Exception) {
-                logger.error("Cannot persist event", e)
+        consumerTags.add(registerEthWithdrawalProofConsumer(SORA_EVENTS_PERSIST_QUEUE_NAME) { event ->
+            persistencyExecutorService.submit {
+                try {
+                    logger.info("Persist event. Event $event")
+                    ethWithdrawalProofRepository.save(EthWithdrawalProofs.mapDomain(event))
+                    logger.info("Event $event has been successfully persisted")
+                } catch (e: CannotCreateTransactionException) {
+                    if (e.cause is JDBCConnectionException) {
+                        throw RepeatableError("Cannot connect to DB", e)
+                    } else {
+                        logger.error("Cannot persist event", e)
+                    }
+                } catch (e: Exception) {
+                    logger.error("Cannot persist event", e)
+                }
             }
         })
     }
@@ -113,20 +132,29 @@ class SoraNotificationListener(
     private fun registerEthWithdrawalProofConsumer(
         queueName: String,
         consumer: (SoraEthWithdrawalProofsEvent) -> Unit
-    ) = channel.basicConsume(queueName, true,
+    ) = channel.basicConsume(queueName, false,
         { _: String, delivery: Delivery ->
             val json = String(delivery.body)
             val eventType = delivery.properties.headers[EVENT_TYPE_HEADER]?.toString() ?: ""
             logger.info("Got event type $eventType with message ${String(delivery.body)}")
-            when (eventType) {
-                // Handle proof collection events
-                SoraEthWithdrawalProofsEvent::class.java.canonicalName -> {
-                    val withdrawalEventProof = gson.fromJson(json, SoraEthWithdrawalProofsEvent::class.java)
-                    consumer(withdrawalEventProof)
+            try {
+                when (eventType) {
+                    // Handle proof collection events
+                    SoraEthWithdrawalProofsEvent::class.java.canonicalName -> {
+                        val withdrawalEventProof = gson.fromJson(json, SoraEthWithdrawalProofsEvent::class.java)
+                        consumer(withdrawalEventProof)
+                    }
+                    else -> {
+                        logger.warn("Event type $eventType is not supported")
+                    }
                 }
-                else -> {
-                    logger.warn("Event type $eventType is not supported")
-                }
+                channel.basicAck(delivery.envelope.deliveryTag, false)
+            } catch (e: RepeatableError) {
+                logger.error("Cannot handle delivery. Message ${String(delivery.body)}. Try to re-queue.", e)
+                channel.basicNack(delivery.envelope.deliveryTag, false, true)
+            } catch (e: Exception) {
+                logger.error("Cannot handle delivery. Message ${String(delivery.body)}", e)
+                channel.basicAck(delivery.envelope.deliveryTag, false)
             }
         }
         , { _ -> })
@@ -136,6 +164,8 @@ class SoraNotificationListener(
             channel.basicCancel(consumerTag)
         }
         connection.close()
+        rxExecutorService.shutdownNow()
+        persistencyExecutorService.shutdownNow()
     }
 
     companion object : KLogging()


### PR DESCRIPTION
We need to acknowledge events manually and push them back to their corresponding queues in case of errors. Plus separate thread pools for persisting and reactive handlers.